### PR TITLE
fix: replace 'any' type with proper TypeScript types to resolve ESLin…

### DIFF
--- a/resources/js/hooks/useLang.tsx
+++ b/resources/js/hooks/useLang.tsx
@@ -35,11 +35,11 @@ export function useLang() {
 
     function getValueFromKey(key: string): string | undefined {
         const segments = key.split('.')
-        let current: any = lang
+        let current: LangValue | undefined = lang
 
         for (const segment of segments) {
             if (typeof current !== 'object' || current === null) return undefined
-            current = current[segment]
+            current = current[segment] as LangValue | undefined
         }
 
         return typeof current === 'string' ? current : undefined


### PR DESCRIPTION
# Fix TypeScript ESLint Warning - Replace `any` type

## 🐛 Problem
The `useLang` hook contains a TypeScript `any` type that triggers ESLint warning:
```
@typescript-eslint/no-explicit-any: Unexpected any. Specify a different type.
```

## ✅ Solution
- Replace `any` type with proper `LangValue | undefined` type
- Add type casting for safe array access
- Maintain backward compatibility and functionality

## 📝 Changes Made
- **Before**: `let current: any = lang`
- **After**: `let current: LangValue | undefined = lang`
- Added proper type casting: `current[segment] as LangValue | undefined`

## 📦 Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## 🔍 Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No breaking changes introduced  
- [x] TypeScript types are properly defined
- [x] ESLint warning resolved
- [x] Hook functionality preserved
- [x] Type safety maintained