### PR TITLE
Allow useLang.tsx to use laravel translation syntax for Vue

### DIFF
--- a/resources/js/composables/useLang.ts
+++ b/resources/js/composables/useLang.ts
@@ -27,10 +27,12 @@ export function useLang() {
     }
 
     function replacePlaceholders(text: string, replaces: Replaces): string {
-        return Object.entries(replaces).reduce(
-            (acc, [key, val]) => acc.replaceAll(`{${key}}`, String(val)),
-            text
-        )
+        return Object.entries(replaces).reduce((acc, [key, val]) => {
+            const value = String(val)
+            return acc
+                .replaceAll(`:${key}`, value)
+                .replaceAll(`{${key}}`, value)
+        }, text)
     }
 
     function getValueFromKey(key: string): string | undefined {


### PR DESCRIPTION
Currently useLang.tsx uses brackets to replace placeholders, like 
```
lang.php
"text => "This is a {placeholder}"

component.jsx/tsx
trans('text", {placeholder: "a test"})
```

This does not allow Laravel standard column translations placeholders with ":placeholder".

Now this is also allowed

```
lang.php
"text => "This is a :placeholder"

component.jsx/tsx
trans('text", {placeholder: "a test"})
```

This way the same file can be use for Blade as well as for JSX/TSX Intertia components