### PR TITLE
Replace Laravel style parameters `:key`

### DIFF
--- a/resources/js/composables/useLang.ts
+++ b/resources/js/composables/useLang.ts
@@ -28,7 +28,7 @@ export function useLang() {
 
     function replacePlaceholders(text: string, replaces: Replaces): string {
         return Object.entries(replaces).reduce(
-            (acc, [key, val]) => acc.replaceAll(`{${key}}`, String(val)),
+            (acc, [key, val]) => acc.replaceAll(`:${key}`, String(val)).replaceAll(`{${key}}`, String(val)),
             text
         )
     }


### PR DESCRIPTION
Laravel translation strings use the `:key` format to define parameters.

https://laravel.com/docs/12.x/localization#replacing-parameters-in-translation-strings

This PR will work with the official Laravel parameter format `:key` but keep the current `{key}` format working for backwards compatibility.
