### PR TITLE
docs: add Svelte support references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## About Laravel Lang Sync Inertia
 
-Laravel Lang Sync Inertia is a lightweight package for sharing Laravel translation files with Inertia.js applications. It provides a simple way to make backend language files available inside Vue 3 and React pages without manually passing translation props in every response.
+Laravel Lang Sync Inertia is a lightweight package for sharing Laravel translation files with Inertia.js applications. It provides a simple way to make backend language files available inside Vue 3, React, and Svelte pages without manually passing translation props in every response.
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://getcomposer.org/schema.json",
     "name": "erag/laravel-lang-sync-inertia",
-    "description": "A powerful Laravel package for syncing and managing language translations across backend and Inertia.js (Vue/React) frontends, offering effortless localization, auto-sync features, and smooth multi-language support for modern Laravel applications.",
+    "description": "A powerful Laravel package for syncing and managing language translations across backend and Inertia.js (Vue/React/Svelte) frontends, offering effortless localization, auto-sync features, and smooth multi-language support for modern Laravel applications.",
     "license": "MIT",
     "keywords": [
         "laravel",
@@ -22,6 +22,7 @@
         "laravel-i18n",
         "vue i18n",
         "react i18n",
+        "svelte i18n",
         "translation-helper",
         "dynamic-translations"
     ],

--- a/resources/boost/skills/laravel-lang-sync-inertia/SKILL.md
+++ b/resources/boost/skills/laravel-lang-sync-inertia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: laravel-lang-sync-inertia
-description: "Activate when the user is adding, debugging, or documenting Laravel to Inertia translation syncing with erag/laravel-lang-sync-inertia. Use for syncLangFiles(), Lang facade usage, shared Inertia lang props, generated frontend JSON translations, config/inertia-lang.php, package install or generate commands, Vue or React frontend lang() helpers, pluralization helpers, and locale-aware loading."
+description: "Activate when the user is adding, debugging, or documenting Laravel to Inertia translation syncing with erag/laravel-lang-sync-inertia. Use for syncLangFiles(), Lang facade usage, shared Inertia lang props, generated frontend JSON translations, config/inertia-lang.php, package install or generate commands, Vue, React, or Svelte frontend lang() helpers, pluralization helpers, and locale-aware loading."
 license: MIT
 metadata:
   author: Er Amit Gupta
@@ -39,7 +39,7 @@ Load only the reference file you need:
 4. Choose one loading strategy:
    - call `syncLangFiles()` inside the controller action before returning `Inertia::render(...)`, or
    - run `php artisan erag:generate-lang` to generate JSON translation files for the configured output path
-5. Read translations directly inside each Vue or React page/component with `lang()` from `@erag/lang-sync-inertia/vue` or `@erag/lang-sync-inertia/react`.
+5. Read translations directly inside each Vue, React, or Svelte page/component with `lang()` from `@erag/lang-sync-inertia/vue`, `@erag/lang-sync-inertia/react`, or `@erag/lang-sync-inertia/svelte`.
 
 ## Important Behavior
 
@@ -51,9 +51,10 @@ Load only the reference file you need:
 - When generated JSON files are present, the package auto-loads all generated translation groups for the current locale. You do not need to call `syncLangFiles()` for those generated groups.
 - Generated JSON translations are merged first and runtime-loaded translations win on conflicts through `array_replace_recursive`.
 - The current locale comes from `app()->getLocale()`.
-- Vue and React consumers should prefer the dedicated entrypoints:
+- Vue, React, and Svelte consumers should prefer the dedicated entrypoints:
   - `@erag/lang-sync-inertia/vue`
   - `@erag/lang-sync-inertia/react`
+  - `@erag/lang-sync-inertia/svelte`
 - Do not configure this package in Vite, `app.ts`, or `app.js`.
 - Do not register an Inertia app plugin/provider for frontend translation helpers.
 - Import `lang()` in the page or component that needs translations.
@@ -89,5 +90,5 @@ When editing the package itself, also review the generated diff for `resources/b
 - Calling `syncLangFiles()` after returning the Inertia response
 - Expecting translations to appear in Blade views instead of Inertia props
 - Forgetting `php artisan lang:publish` in apps that do not yet have `lang/{locale}` files
-- Importing from the root frontend package for new code instead of `/vue` or `/react`
+- Importing from the root frontend package for new code instead of `/vue`, `/react`, or `/svelte`
 - Changing config paths without updating deployment or build steps that rely on generated JSON

--- a/resources/boost/skills/laravel-lang-sync-inertia/references/api.md
+++ b/resources/boost/skills/laravel-lang-sync-inertia/references/api.md
@@ -103,7 +103,7 @@ Frontend code should treat `lang` as the translation root for helper lookups lik
 
 The companion frontend package exposes dedicated framework entrypoints:
 
-Use these helpers directly inside the Vue or React page/component that needs translations. Do not configure this package in Vite, `app.ts`, or `app.js`.
+Use these helpers directly inside the Vue, React, or Svelte page/component that needs translations. Do not configure this package in Vite, `app.ts`, or `app.js`.
 
 ### Vue
 
@@ -116,6 +116,14 @@ import { lang } from '@erag/lang-sync-inertia/vue';
 ```tsx
 import { lang } from '@erag/lang-sync-inertia/react';
 ```
+
+### Svelte
+
+```ts
+import { lang } from '@erag/lang-sync-inertia/svelte';
+```
+
+Requires `@inertiajs/svelte` v3 (Svelte 5). The `page` reactive state from `@inertiajs/svelte` is read at call time, so helpers work correctly inside `$derived` expressions and reactive contexts.
 
 The `lang()` helper returns methods including:
 

--- a/resources/boost/skills/laravel-lang-sync-inertia/references/examples.md
+++ b/resources/boost/skills/laravel-lang-sync-inertia/references/examples.md
@@ -143,7 +143,7 @@ export default function Dashboard() {
 Use the helper directly inside the Svelte page or component. Do not configure Vite, `app.ts`, or `app.js`. Requires `@inertiajs/svelte` v3 (Svelte 5).
 
 ```svelte
-<script lang="ts">
+<script module lang="ts">
 import { lang } from '@erag/lang-sync-inertia/svelte';
 
 const { __, trans, transChoice } = lang();

--- a/resources/boost/skills/laravel-lang-sync-inertia/references/examples.md
+++ b/resources/boost/skills/laravel-lang-sync-inertia/references/examples.md
@@ -138,6 +138,24 @@ export default function Dashboard() {
 }
 ```
 
+## Svelte Example
+
+Use the helper directly inside the Svelte page or component. Do not configure Vite, `app.ts`, or `app.js`. Requires `@inertiajs/svelte` v3 (Svelte 5).
+
+```svelte
+<script lang="ts">
+import { lang } from '@erag/lang-sync-inertia/svelte';
+
+const { __, trans, transChoice } = lang();
+</script>
+
+<section>
+    <h1>{__('auth.greeting')}</h1>
+    <p>{trans('auth.welcome', { name: 'Amit' })}</p>
+    <p>{transChoice('auth.notifications', 3)}</p>
+</section>
+```
+
 ## Multiple Group Example
 
 Load multiple translation groups when the page uses more than one namespace:
@@ -172,6 +190,12 @@ const { lang } = usePage().props;
 import { usePage } from '@inertiajs/react';
 
 const { lang } = usePage().props;
+```
+
+```ts
+import { page } from '@inertiajs/svelte';
+
+const lang = $derived(page.props.lang);
 ```
 
 ## JSON Export Example

--- a/resources/boost/skills/laravel-lang-sync-inertia/references/package.md
+++ b/resources/boost/skills/laravel-lang-sync-inertia/references/package.md
@@ -138,6 +138,7 @@ The package is designed for the companion NPM package:
 
 - `@erag/lang-sync-inertia/vue`
 - `@erag/lang-sync-inertia/react`
+- `@erag/lang-sync-inertia/svelte`
 
 Frontend helpers read from the shared `lang` prop and expose:
 
@@ -145,7 +146,7 @@ Frontend helpers read from the shared `lang` prop and expose:
 - `trans()` for replacement-heavy lookups
 - `transChoice()` and `trans_choice()` for pluralization
 
-Use the helper directly in each page or component that needs translations. Do not configure the helper in Vite, `app.ts`, or `app.js`, and do not register it as an Inertia app plugin/provider.
+Use the helper directly in each page or component that needs translations. Do not configure the helper in Vite, `app.ts`, or `app.js`, and do not register it as an Inertia app plugin/provider. For Svelte, requires `@inertiajs/svelte` v3 (Svelte 5).
 
 ## Configuration
 
@@ -172,5 +173,5 @@ For a typical host app:
 3. Publish Laravel language files if needed.
 4. Run `php artisan erag:install-lang`.
 5. Call `syncLangFiles()` in each Inertia controller action that needs translations.
-6. Import `lang()` directly inside each Vue or React page/component that needs translations.
+6. Import `lang()` directly inside each Vue, React, or Svelte page/component that needs translations.
 7. Optionally run `php artisan erag:generate-lang` for build-time JSON output.


### PR DESCRIPTION
## Summary
- update package, README, and skill docs to mention Svelte support alongside Vue and React
- add Svelte framework guidance in the skill references
- point readers to the dedicated svelte entrypoint and @inertiajs/svelte usage

## Related
- https://github.com/eramitgupta/lang-sync-inertia/pull/8
- https://github.com/eramitgupta/erag/pull/2

## Notes
- this follows the feedback from PR #8 and keeps the backend docs aligned with the frontend package and main docs repo